### PR TITLE
Wait for Process IDs to terminate after killing them

### DIFF
--- a/undetected_chromedriver/__init__.py
+++ b/undetected_chromedriver/__init__.py
@@ -751,8 +751,9 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
     def quit(self):
         try:
             self.service.process.kill()
+            os.waitpid(self.service.process.pid, 0)
             logger.debug("webdriver process ended")
-        except (AttributeError, RuntimeError, OSError):
+        except (AttributeError, ChildProcessError, RuntimeError, OSError):
             pass
         try:
             self.reactor.event.set()
@@ -761,6 +762,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             pass
         try:
             os.kill(self.browser_pid, 15)
+            os.waitpid(self.browser_pid, 0)
             logger.debug("gracefully closed browser")
         except Exception as e:  # noqa
             pass
@@ -839,6 +841,12 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             and hasattr(self.service.process, "kill")
         ):
             self.service.process.kill()
+
+            try:
+                # Prevent zombie processes
+                os.waitpid(self.service.process.pid, 0)
+            except ChildProcessError:
+                pass
 
 
 def find_chrome_executable():


### PR DESCRIPTION
This prevents zombie (defunct) processes on *nix systems. The waitpid() function throws a ChildProcessError on Windows, so that is handled accordingly.